### PR TITLE
Fixing `raise` issue on seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,10 @@ def open_asset(file_name)
 end
 
 # Only run on development (local) instances not on production, etc.
-raise "Development seeds only (for now)!" unless Rails.env.development?
+unless Rails.env.development?
+  puts "Development seeds only (for now)!"
+  exit 0
+end
 
 # Let's do this ...
 


### PR DESCRIPTION
Running `rake db:setup` shouldn't blow up when RAILS_ENV=test. It should
simply exit gracefully instead.