### PR TITLE
Flash errors on redirect

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -12,11 +12,11 @@ class OrdersController < ApplicationController
       empty_cart!
       redirect_to order, notice: 'Your Order has been placed.'
     else
-      redirect_to cart_path, error: order.errors.full_messages.first
+      redirect_to cart_path, flash: { error: order.errors.full_messages.first }
     end
 
   rescue Stripe::CardError => e
-    redirect_to cart_path, error: e.message
+    redirect_to cart_path, flash: { error: e.message }
   end
 
   private


### PR DESCRIPTION
There are a couple of redirects like this:

```ruby
redirect_to cart_path, error: e.message
```

which need to look like this:

```ruby
redirect_to cart_path, flash: { error: e.message }
```

`:notice` and `:alert` are the only flash names treated specially by `redirect_to`.