### PR TITLE
Add pull request template, tell students not to PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+Note to students:
+-----------------
+
+You *don't* need to submit pull requests (PRs) for your solutions. We don't want to merge your changes! Our version stays unsolved for future students to fork.
+
+When you've completed the project, just submit your repo URL in Compass for evaluation.


### PR DESCRIPTION
Students often make PRs for their feature branches (I'm guessing they see the prompt in Github when they push to their own fork, and just go for it).

The pull request template will give them something to read about it.

Suggested in: lighthouse-labs/2016-web-curriculum-activities#481