### PR TITLE
Loosen ruby requirement to 2.3.*

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby "2.3.0"
+ruby "~> 2.3.0"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.6'


### PR DESCRIPTION
Anticipating an updated version of ruby in the vagrant file, locking specifically to 2.3.0 creates some confusion when you first checkout and enter jungle-rails.